### PR TITLE
Added support for Hudi

### DIFF
--- a/benchmarks/run-benchmark.py
+++ b/benchmarks/run-benchmark.py
@@ -21,6 +21,7 @@ from scripts.benchmarks import *
 
 delta_version = "2.1.0"
 iceberg_version = "0.14.1"
+hudi_version = "0.12.2"
 
 # Benchmark name to their specifications. See the imported benchmarks.py for details of benchmark.
 
@@ -53,6 +54,9 @@ benchmarks = {
     #  NB: Cannot run ETL operations on Parquet tables
     "etl-1gb-delta": DeltaETLBenchmarkSpec(delta_version=delta_version, scale_in_gb=1),
     "etl-1tb-delta": DeltaETLBenchmarkSpec(delta_version=delta_version, scale_in_gb=1000),
+
+    "etl-1gb-hudi": HudiETLBenchmarkSpec(hudi_version=hudi_version, scale_in_gb=1),
+    "etl-1tb-hudi": HudiETLBenchmarkSpec(hudi_version=hudi_version, scale_in_gb=1000),
 
     "etl-1gb-iceberg": IcebergETLBenchmarkSpec(iceberg_version=iceberg_version, scale_in_gb=1),
     "etl-1tb-iceberg": IcebergETLBenchmarkSpec(iceberg_version=iceberg_version, scale_in_gb=1000),

--- a/benchmarks/scripts/benchmarks.py
+++ b/benchmarks/scripts/benchmarks.py
@@ -196,6 +196,34 @@ class DeltaETLBenchmarkSpec(ETLBenchmarkSpec, DeltaBenchmarkSpec):
         super().__init__(delta_version=delta_version, scale_in_gb=scale_in_gb, write_mode=write_mode)
 
 
+# ============== Hudi benchmark specifications ==============
+
+
+class HudiBenchmarkSpec(BenchmarkSpec):
+    """
+    Specification of a benchmark using the Hudi format
+    """
+    def __init__(self, hudi_version, benchmark_main_class, main_class_args=None, **kwargs):
+        hudi_spark_confs = [
+            "spark.serializer=org.apache.spark.serializer.KryoSerializer",
+            "spark.sql.extensions=org.apache.spark.sql.hudi.HoodieSparkSessionExtension",
+            "spark.sql.catalog.spark_catalog=org.apache.spark.sql.hudi.catalog.HoodieCatalog",
+            "spark.sql.catalog.spark_catalog.type=hive",
+        ]
+
+        super().__init__(
+            format_name="hudi",
+            maven_artifacts=f"org.apache.hudi:hudi-spark3.3-bundle_2.12:{hudi_version}",
+            spark_confs=hudi_spark_confs,
+            benchmark_main_class=benchmark_main_class,
+            main_class_args=main_class_args,
+            **kwargs
+        )
+
+class HudiETLBenchmarkSpec(ETLBenchmarkSpec, HudiBenchmarkSpec):
+    def __init__(self, hudi_version, scale_in_gb=1, write_mode="copy-on-write"):
+        super().__init__(hudi_version=hudi_version, scale_in_gb=scale_in_gb, write_mode=write_mode)
+
 
 # ============== Iceberg benchmark specifications ==============
 

--- a/benchmarks/src/main/scala/benchmark/etl/ETLBenchmark.scala
+++ b/benchmarks/src/main/scala/benchmark/etl/ETLBenchmark.scala
@@ -110,7 +110,10 @@ class ETLBenchmark(conf: ETLBenchmarkConf) extends Benchmark(conf) {
          |  'hoodie.table.partition.fields' = 'ss_sold_date_sk',
          |  'hoodie.table.keygenerator.class' = 'org.apache.hudi.keygen.ComplexKeyGenerator',
          |  'hoodie.parquet.compression.codec' = 'snappy',
-         |  'hoodie.datasource.write.hive_style_partitioning' = 'true'
+         |  'hoodie.datasource.write.hive_style_partitioning' = 'true',
+         |  'hoodie.sql.insert.mode'= 'non-strict',
+         |  'hoodie.sql.bulk.insert.enable' = 'true',
+         |  'hoodie.combine.before.insert' = 'false'
          |)""".stripMargin
 
     case "delta" => ""


### PR DESCRIPTION
## Description

This PR adds support for Hudi into BrooklynData benchmarking suite.

## How was this patch tested?

Adding Hudi support to BrooklynData benchmarks we run this suite on EMR w/ the same configuration as have been called out in this [blog](https://brooklyndata.co/blog/benchmarking-open-table-formats), obtaining following results:

<img width="896" alt="Screenshot 2023-01-03 at 9 55 40 PM" src="https://user-images.githubusercontent.com/428277/210493034-c008ec54-45cd-4d7e-a1b3-6d6ea1b3939a.png">

<img width="898" alt="Screenshot 2023-01-03 at 9 55 50 PM" src="https://user-images.githubusercontent.com/428277/210493064-4683bbb1-bfb8-4ff3-987a-a4887a711de3.png">


Things to note:

 - Hudi by default adds materialized meta-fields (like primary-key, partition-path, etc) to every record which help it subsequently speed up updates (by the ways of being able to leverage Bloom index for ex) as well as powering Hudi's other stand-out features such as [Incremental reads](https://hudi.apache.org/docs/querying_data#spark-incr-query) (enabling Incremental ETL for ex). Such amendment comes at the expense of slightly slower [bulk-insert operation](https://hudi.apache.org/docs/write_operations#bulk_insert) (in `CREATE TABLE AS SELECT`)
 - Hudi's upsert performance (step 2) is dominated by unnecessary conversion to Avro, which is what community currently [focusing on rectifying](https://github.com/apache/hudi/blob/master/rfc/rfc-46/rfc-46.md)
 - Hudi performs better in workloads w/ higher _selectivity_ (step 3, ie reading just a handful of files), since it relies on [Bloom index](https://hudi.apache.org/docs/indexing#index-types-in-hudi)
 - Hudi sets lower target file-size limit of 120Mb to balance Query performance against Write amplification problem, which is lower than Delta's default value (of [256Mb](https://learn.microsoft.com/en-us/azure/databricks/delta/tune-file-size)) and therefore makes Hudi produce more files and therefore affecting its query performance relative to Delta. We deliberately not tried to tune this setting up for more fair comparison.

## Does this PR introduce _any_ user-facing changes?

N/A
